### PR TITLE
added test and fixed sn_or_name null behavior

### DIFF
--- a/hwmux/device_resource.go
+++ b/hwmux/device_resource.go
@@ -192,7 +192,11 @@ func (r *DeviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	// Map response body to model
 	data.ID = types.StringValue(strconv.Itoa(int(device.GetId())))
-	data.Sn_or_name = types.StringValue(device.GetSnOrName())
+	if device.GetSnOrName() != "" {
+		data.Sn_or_name = types.StringValue(device.GetSnOrName())
+	} else {
+		data.Sn_or_name = types.StringNull()
+	}
 	data.Is_wstk = types.BoolValue(device.GetIsWstk())
 	if device.GetUri() != "" {
 		data.Uri = types.StringValue(device.GetUri())
@@ -355,7 +359,11 @@ func updateDeviceModelFromResponse(device *hwmux.WriteOnlyDevice, plan *DeviceRe
 	client *hwmux.APIClient) (err error) {
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(strconv.Itoa(int(device.GetId())))
-	plan.Sn_or_name = types.StringValue(device.GetSnOrName())
+	if device.GetSnOrName() != "" {
+		plan.Sn_or_name = types.StringValue(device.GetSnOrName())
+	} else {
+		plan.Sn_or_name = types.StringNull()
+	}
 	plan.Is_wstk = types.BoolValue(device.GetIsWstk())
 	if device.GetUri() != "" {
 		plan.Uri = types.StringValue(device.GetUri())

--- a/hwmux/device_resource_test.go
+++ b/hwmux/device_resource_test.go
@@ -113,3 +113,37 @@ resource "hwmux_device" "test" {
         },
     })
 }
+
+
+func TestAccDeviceResourceNoSnOrName(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+        Steps: []resource.TestStep{
+            // Create and Read testing
+            {
+                Config: providerConfig + `
+resource "hwmux_device" "test" {
+    part = "Part_no_0"
+    room = "Room_0"
+    permission_groups = ["Staff users"]
+}
+`,
+                Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("hwmux_device.test", "part", "Part_no_0"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "room", "Room_0"),
+                    resource.TestCheckResourceAttr("hwmux_device.test", "permission_groups.#", "1"),
+                    resource.TestCheckResourceAttr("hwmux_device.test", "permission_groups.0", "Staff users"),
+                    // Verify the device item has Computed attributes filled.
+                    resource.TestCheckResourceAttr("hwmux_device.test", "is_wstk", "false"),
+                    resource.TestCheckResourceAttr("hwmux_device.test", "online", "true"),
+                    resource.TestCheckResourceAttr("hwmux_device.test", "metadata", "{}"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "location_metadata", "{}"),
+                    // Verify dynamic values have any value set in the state.
+                    resource.TestCheckResourceAttrSet("hwmux_device.test", "id"),
+                    resource.TestCheckResourceAttrSet("hwmux_device.test", "last_updated"),
+                ),
+            },
+            // Delete testing automatically occurs in TestCase
+        },
+    })
+}


### PR DESCRIPTION
missing sn_or_name field would case a state error because an empty string ("") was replacing the null value. Now the empty string is ignored.