### PR TITLE
Subtask/utf 3835 support enable ahs actions

### DIFF
--- a/docs/data-sources/device_group.md
+++ b/docs/data-sources/device_group.md
@@ -23,6 +23,7 @@ DeviceGroup data source
 
 - `devices` (Attributes List) The devices that belong to the Device Group (see [below for nested schema](#nestedatt--devices))
 - `enable_ahs` (Boolean) Enable the Automated Health Service
+- `enable_ahs_actions` (Boolean) Allow the Automated Health Service to take DeviceGroups offline when they are unhealthy.
 - `metadata` (String) The metadata of the Device Group.
 - `name` (String) Device Group name. Must be unique.
 

--- a/docs/resources/device_group.md
+++ b/docs/resources/device_group.md
@@ -14,11 +14,12 @@ Device Group resource.
 
 ```terraform
 resource "hwmux_device_group" "new_testbed" {
-  name              = "name_no_spaces"
-  metadata          = jsonencode(yamldecode(file("example.yaml")))
-  devices           = [1, 2]
-  permission_groups = ["Example group name"]
-  enable_ahs        = true
+  name               = "name_no_spaces"
+  metadata           = jsonencode(yamldecode(file("example.yaml")))
+  devices            = [1, 2]
+  permission_groups  = ["Example group name"]
+  enable_ahs         = true
+  enable_ahs_actions = true
 }
 ```
 
@@ -34,6 +35,7 @@ resource "hwmux_device_group" "new_testbed" {
 ### Optional
 
 - `enable_ahs` (Boolean) Enable the Automated Health Service
+- `enable_ahs_actions` (Boolean) Allow the Automated Health Service to take DeviceGroups offline when they are unhealthy.
 - `metadata` (String) The metadata of the Device Group.
 
 ### Read-Only

--- a/examples/resources/hwmux_device_group/resource.tf
+++ b/examples/resources/hwmux_device_group/resource.tf
@@ -1,7 +1,8 @@
 resource "hwmux_device_group" "new_testbed" {
-  name              = "name_no_spaces"
-  metadata          = jsonencode(yamldecode(file("example.yaml")))
-  devices           = [1, 2]
-  permission_groups = ["Example group name"]
-  enable_ahs        = true
+  name               = "name_no_spaces"
+  metadata           = jsonencode(yamldecode(file("example.yaml")))
+  devices            = [1, 2]
+  permission_groups  = ["Example group name"]
+  enable_ahs         = true
+  enable_ahs_actions = true
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-hwmux
 go 1.18
 
 require (
-	github.com/Silabs-UTF/hwmux-client-golang/v2 v2.19.3
+	github.com/Silabs-UTF/hwmux-client-golang/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/Silabs-UTF/hwmux-client-golang/v2 v2.19.3 h1:mzYYD83u/G8DghMM8kbrFEQe8NoibOTvOcj16eY1wq8=
-github.com/Silabs-UTF/hwmux-client-golang/v2 v2.19.3/go.mod h1:+4OyAlvqC+FNh2w86bxhQK0KpbwaFeITjwTSglVBqx4=
+github.com/Silabs-UTF/hwmux-client-golang/v2 v2.24.0 h1:JMYtIL70mSga+VWcK04xwNJelYhThgZTdeMyYICmO/I=
+github.com/Silabs-UTF/hwmux-client-golang/v2 v2.24.0/go.mod h1:+4OyAlvqC+FNh2w86bxhQK0KpbwaFeITjwTSglVBqx4=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=

--- a/hwmux/api_utils.go
+++ b/hwmux/api_utils.go
@@ -20,7 +20,7 @@ func GetDevice(client *hwmux.APIClient, diagnostics *diag.Diagnostics, id int32)
 // Get deviceGroup, err and set error
 func GetDeviceGroup(client *hwmux.APIClient, diagnostics *diag.Diagnostics, id int32) (
 	deviceGroup *hwmux.DeviceGroup, httpRes *http.Response, err error) {
-	deviceGroup, httpRes, err = client.GroupsApi.GroupsRetrieve(context.Background(), id).Execute()
+	deviceGroup, httpRes, err = client.GroupsApi.GroupsRetrieve(context.Background(), id).IncludePermissionGroups(true).Execute()
 	handleError(httpRes, err, diagnostics, "Device Group")
 	return
 }
@@ -28,7 +28,7 @@ func GetDeviceGroup(client *hwmux.APIClient, diagnostics *diag.Diagnostics, id i
 // Get label, err and set error
 func GetLabel(client *hwmux.APIClient, diagnostics *diag.Diagnostics, id int32) (
 	label *hwmux.Label, httpRes *http.Response, err error) {
-	label, httpRes, err = client.LabelsApi.LabelsRetrieve(context.Background(), id).Execute()
+	label, httpRes, err = client.LabelsApi.LabelsRetrieve(context.Background(), id).IncludePermissionGroups(true).Execute()
 	handleError(httpRes, err, diagnostics, "Label")
 	return
 }

--- a/hwmux/api_utils.go
+++ b/hwmux/api_utils.go
@@ -12,7 +12,7 @@ import (
 // Get device, err and set error
 func GetDevice(client *hwmux.APIClient, diagnostics *diag.Diagnostics, id int32) (
 	device *hwmux.DeviceSerializerPublic, httpRes *http.Response, err error) {
-	device, httpRes, err = client.DevicesApi.DevicesRetrieve(context.Background(), id).Execute()
+	device, httpRes, err = client.DevicesApi.DevicesRetrieve(context.Background(), id).IncludePermissionGroups(true).Execute()
 	handleError(httpRes, err, diagnostics, "Device")
 	return
 }

--- a/hwmux/device_resource.go
+++ b/hwmux/device_resource.go
@@ -339,6 +339,7 @@ func (r *DeviceResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
+	// if it's offline, set it back online to remove the reservation for the offline status
 	if !data.Online.ValueBool() {
 		id, _ := strconv.Atoi(data.ID.ValueString())
 		r.setDeviceStatusFromPlan(&resp.Diagnostics, int32(id), hwmux.ACTIVE)

--- a/hwmux/device_resource.go
+++ b/hwmux/device_resource.go
@@ -255,10 +255,7 @@ func (r *DeviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	data.Part = types.StringValue(device.Part.GetPartNo())
 
-	permissionGroups, err := GetPermissionGroupsForDevice(r.client, &resp.Diagnostics, device.GetId())
-	if err != nil {
-		return
-	}
+	permissionGroups := device.GetPermissionGroups()
 	data.PermissionGroups = make([]types.String, len(permissionGroups))
 	for i, aGroup := range permissionGroups {
 		data.PermissionGroups[i] = types.StringValue(aGroup)

--- a/hwmux/device_resource_test.go
+++ b/hwmux/device_resource_test.go
@@ -74,6 +74,33 @@ resource "hwmux_device" "test" {
 					resource.TestCheckResourceAttr("hwmux_device.test", "location_metadata", "{}"),
 				),
 			},
+			// (Delete testing automatically occurs in TestCase)
+			// Test unsetting the online field, which should set online back to true
+			{
+				Config: providerConfig + `
+resource "hwmux_device" "test" {
+	sn_or_name = "test_device"
+	uri = "88.8.8.8"
+	part = "Part_no_0"
+	room = "Room_0"
+    permission_groups = ["All users"]
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify first device item updated
+					resource.TestCheckResourceAttr("hwmux_device.test", "sn_or_name", "test_device"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "uri", "88.8.8.8"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "part", "Part_no_0"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "room", "Room_0"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "online", "true"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "permission_groups.#", "1"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "permission_groups.0", "All users"),
+					// Verify first coffee item has Computed attributes updated.
+					resource.TestCheckResourceAttr("hwmux_device.test", "is_wstk", "false"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "metadata", "{}"),
+					resource.TestCheckResourceAttr("hwmux_device.test", "location_metadata", "{}"),
+				),
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/hwmux/device_resource_test.go
+++ b/hwmux/device_resource_test.go
@@ -75,33 +75,6 @@ resource "hwmux_device" "test" {
 				),
 			},
 			// (Delete testing automatically occurs in TestCase)
-			// Test unsetting the online field, which should set online back to true
-			{
-				Config: providerConfig + `
-resource "hwmux_device" "test" {
-	sn_or_name = "test_device"
-	uri = "88.8.8.8"
-	part = "Part_no_0"
-	room = "Room_0"
-    permission_groups = ["All users"]
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Verify first device item updated
-					resource.TestCheckResourceAttr("hwmux_device.test", "sn_or_name", "test_device"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "uri", "88.8.8.8"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "part", "Part_no_0"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "room", "Room_0"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "online", "true"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "permission_groups.#", "1"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "permission_groups.0", "All users"),
-					// Verify first coffee item has Computed attributes updated.
-					resource.TestCheckResourceAttr("hwmux_device.test", "is_wstk", "false"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "metadata", "{}"),
-					resource.TestCheckResourceAttr("hwmux_device.test", "location_metadata", "{}"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
 		},
 	})
 }

--- a/hwmux/devicegroup_data_source.go
+++ b/hwmux/devicegroup_data_source.go
@@ -27,7 +27,7 @@ type DeviceGroupDataSourceModel struct {
 	Name       types.String        `tfsdk:"name"`
 	Devices    []nestedDeviceModel `tfsdk:"devices"`
 	Enable_ahs types.Bool          `tfsdk:"enable_ahs"`
-	Enable_ahs_actions types.Bool `tfsdk:"enable_ahs"`
+	Enable_ahs_actions types.Bool `tfsdk:"enable_ahs_actions"`
 	Metadata   types.String        `tfsdk:"metadata"`
 }
 
@@ -120,6 +120,7 @@ func (d *DeviceGroupDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.ID = types.Int64Value(int64(deviceGroup.GetId()))
 	data.Name = types.StringValue(deviceGroup.GetName())
 	data.Enable_ahs = types.BoolValue(deviceGroup.GetEnableAhs())
+	data.Enable_ahs_actions = types.BoolValue(deviceGroup.GetEnableAhsActions())
 
 	err = MarshalMetadataSetError(deviceGroup.GetMetadata(), &resp.Diagnostics, "deviceGroup", &data.Metadata)
 	if err != nil {

--- a/hwmux/devicegroup_data_source.go
+++ b/hwmux/devicegroup_data_source.go
@@ -23,12 +23,12 @@ type DeviceGroupDataSource struct {
 
 // deviceGroupDataSourceModel maps the data source schema data.
 type DeviceGroupDataSourceModel struct {
-	ID         types.Int64         `tfsdk:"id"`
-	Name       types.String        `tfsdk:"name"`
-	Devices    []nestedDeviceModel `tfsdk:"devices"`
-	Enable_ahs types.Bool          `tfsdk:"enable_ahs"`
-	Enable_ahs_actions types.Bool `tfsdk:"enable_ahs_actions"`
-	Metadata   types.String        `tfsdk:"metadata"`
+	ID                 types.Int64         `tfsdk:"id"`
+	Name               types.String        `tfsdk:"name"`
+	Devices            []nestedDeviceModel `tfsdk:"devices"`
+	Enable_ahs         types.Bool          `tfsdk:"enable_ahs"`
+	Enable_ahs_actions types.Bool          `tfsdk:"enable_ahs_actions"`
+	Metadata           types.String        `tfsdk:"metadata"`
 }
 
 type nestedDeviceModel struct {

--- a/hwmux/devicegroup_data_source.go
+++ b/hwmux/devicegroup_data_source.go
@@ -27,6 +27,7 @@ type DeviceGroupDataSourceModel struct {
 	Name       types.String        `tfsdk:"name"`
 	Devices    []nestedDeviceModel `tfsdk:"devices"`
 	Enable_ahs types.Bool          `tfsdk:"enable_ahs"`
+	Enable_ahs_actions types.Bool `tfsdk:"enable_ahs"`
 	Metadata   types.String        `tfsdk:"metadata"`
 }
 
@@ -70,6 +71,10 @@ func (d *DeviceGroupDataSource) Schema(ctx context.Context, req datasource.Schem
 			},
 			"enable_ahs": schema.BoolAttribute{
 				MarkdownDescription: "Enable the Automated Health Service",
+				Computed:            true,
+			},
+			"enable_ahs_actions": schema.BoolAttribute{
+				MarkdownDescription: "Allow the Automated Health Service to take DeviceGroups offline when they are unhealthy.",
 				Computed:            true,
 			},
 		},

--- a/hwmux/devicegroup_data_source_test.go
+++ b/hwmux/devicegroup_data_source_test.go
@@ -19,6 +19,7 @@ func TestAccDeviceGroupDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.hwmux_device_group.test", "id", "1"),
 					// ensure dynamic attributes are populated
 					resource.TestCheckResourceAttrSet("data.hwmux_device_group.test", "enable_ahs"),
+					resource.TestCheckResourceAttrSet("data.hwmux_device_group.test", "enable_ahs_actions"),
 					resource.TestCheckResourceAttrSet("data.hwmux_device_group.test", "metadata"),
 					resource.TestCheckResourceAttrSet("data.hwmux_device_group.test", "devices.0.id"),
 				),

--- a/hwmux/devicegroup_resource.go
+++ b/hwmux/devicegroup_resource.go
@@ -34,13 +34,14 @@ type DeviceGroupResource struct {
 
 // DeviceGroupResourceModel describes the resource data model.
 type DeviceGroupResourceModel struct {
-	ID               types.String   `tfsdk:"id"`
-	Name             types.String   `tfsdk:"name"`
-	Metadata         types.String   `tfsdk:"metadata"`
-	Devices          []types.Int64  `tfsdk:"devices"`
-	PermissionGroups []types.String `tfsdk:"permission_groups"`
-	Enable_ahs       types.Bool     `tfsdk:"enable_ahs"`
-	LastUpdated      types.String   `tfsdk:"last_updated"`
+	ID                 types.String   `tfsdk:"id"`
+	Name               types.String   `tfsdk:"name"`
+	Metadata           types.String   `tfsdk:"metadata"`
+	Devices            []types.Int64  `tfsdk:"devices"`
+	PermissionGroups   []types.String `tfsdk:"permission_groups"`
+	Enable_ahs         types.Bool     `tfsdk:"enable_ahs"`
+	Enable_ahs_actions types.Bool     `tfsdk:"enable_ahs_actions"`
+	LastUpdated        types.String   `tfsdk:"last_updated"`
 }
 
 func (r *DeviceGroupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -86,6 +87,11 @@ func (r *DeviceGroupResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"enable_ahs": schema.BoolAttribute{
 				MarkdownDescription: "Enable the Automated Health Service",
+				Computed:            true,
+				Optional:            true,
+			},
+			"enable_ahs_actions": schema.BoolAttribute{
+				MarkdownDescription: "Allow the Automated Health Service to take DeviceGroups offline when they are unhealthy.",
 				Computed:            true,
 				Optional:            true,
 			},
@@ -181,6 +187,7 @@ func (r *DeviceGroupResource) Read(ctx context.Context, req resource.ReadRequest
 	data.ID = types.StringValue(strconv.Itoa(int(deviceGroup.GetId())))
 	data.Name = types.StringValue(deviceGroup.GetName())
 	data.Enable_ahs = types.BoolValue(deviceGroup.GetEnableAhs())
+	data.Enable_ahs_actions = types.BoolValue(deviceGroup.GetEnableAhsActions())
 
 	err = MarshalMetadataSetError(deviceGroup.GetMetadata(), &resp.Diagnostics, "Device Group", &data.Metadata)
 	if err != nil {
@@ -281,6 +288,9 @@ func createDeviceGroupFromPlan(plan *DeviceGroupResourceModel, diagnostics *diag
 	if !plan.Enable_ahs.IsUnknown() {
 		deviceGroupSerializer.SetEnableAhs(plan.Enable_ahs.ValueBool())
 	}
+	if !plan.Enable_ahs_actions.IsUnknown() {
+		deviceGroupSerializer.SetEnableAhsActions(plan.Enable_ahs_actions.ValueBool())
+	}
 
 	if !plan.Metadata.IsUnknown() {
 		metadata, errorMet := UnmarshalMetadataSetError(plan.Metadata.ValueString(), diagnostics, "deviceGroup")
@@ -313,6 +323,7 @@ func updateDGModelFromResponse(deviceGroup *hwmux.DeviceGroupSerializerWithDevic
 	plan.ID = types.StringValue(strconv.Itoa(int(deviceGroup.GetId())))
 	plan.Name = types.StringValue(deviceGroup.GetName())
 	plan.Enable_ahs = types.BoolValue(deviceGroup.GetEnableAhs())
+	plan.Enable_ahs_actions = types.BoolValue(deviceGroup.GetEnableAhsActions())
 
 	err = MarshalMetadataSetError(deviceGroup.GetMetadata(), diagnostics, "deviceGroup", &plan.Metadata)
 	if err != nil {

--- a/hwmux/devicegroup_resource.go
+++ b/hwmux/devicegroup_resource.go
@@ -199,10 +199,7 @@ func (r *DeviceGroupResource) Read(ctx context.Context, req resource.ReadRequest
 		data.Devices[i] = types.Int64Value(int64(device.GetId()))
 	}
 
-	permissionGroups, err := GetPermissionGroupsForDeviceGroup(r.client, &resp.Diagnostics, deviceGroup.GetId())
-	if err != nil {
-		return
-	}
+	permissionGroups := deviceGroup.GetPermissionGroups()
 	data.PermissionGroups = make([]types.String, len(permissionGroups))
 	for i, aGroup := range permissionGroups {
 		data.PermissionGroups[i] = types.StringValue(aGroup)

--- a/hwmux/devicegroup_resource_test.go
+++ b/hwmux/devicegroup_resource_test.go
@@ -30,6 +30,7 @@ resource "hwmux_device_group" "test" {
 					// Verify dynamic values have any value set in the state.
 					resource.TestCheckResourceAttrSet("hwmux_device_group.test", "id"),
 					resource.TestCheckResourceAttrSet("hwmux_device_group.test", "enable_ahs"),
+					resource.TestCheckResourceAttrSet("hwmux_device_group.test", "enable_ahs_actions"),
 					resource.TestCheckResourceAttrSet("hwmux_device_group.test", "last_updated"),
 				),
 			},

--- a/hwmux/devicegroup_resource_test.go
+++ b/hwmux/devicegroup_resource_test.go
@@ -49,6 +49,7 @@ resource "hwmux_device_group" "test" {
 	name     = "test_dg"
 	devices = [1]
 	enable_ahs = true
+	enable_ahs_actions = true
 	permission_groups = ["Staff users"]
 }
 `,
@@ -59,6 +60,7 @@ resource "hwmux_device_group" "test" {
 					resource.TestCheckResourceAttr("hwmux_device_group.test", "permission_groups.#", "1"),
 					resource.TestCheckResourceAttr("hwmux_device_group.test", "permission_groups.0", "Staff users"),
 					resource.TestCheckResourceAttr("hwmux_device_group.test", "enable_ahs", "true"),
+					resource.TestCheckResourceAttr("hwmux_device_group.test", "enable_ahs_actions", "true"),
 					// Verify the device_group item has Computed attributes filled.
 					resource.TestCheckResourceAttr("hwmux_device_group.test", "metadata", "{}"),
 				),

--- a/hwmux/label_resource.go
+++ b/hwmux/label_resource.go
@@ -185,10 +185,7 @@ func (r *LabelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		data.DeviceGroups[i] = types.Int64Value(int64(deviceGroup))
 	}
 
-	permissionGroups, err := GetPermissionGroupsForLabel(r.client, &resp.Diagnostics, label.GetId())
-	if err != nil {
-		return
-	}
+	permissionGroups := label.GetPermissionGroups()
 	data.PermissionGroups = make([]types.String, len(permissionGroups))
 	for i, aGroup := range permissionGroups {
 		data.PermissionGroups[i] = types.StringValue(aGroup)

--- a/hwmux/provider_test.go
+++ b/hwmux/provider_test.go
@@ -9,7 +9,7 @@ const (
 	providerConfig = `
 provider "hwmux" {
   host  = "http://localhost"
-  token = "a86690a0a1e93c139db8858e039104b30ba38d2c"
+  token = "8164a97ba1324698e838146781a7365fb969edc4"
 }
 `
 )


### PR DESCRIPTION
Added support for the `enable_ahs_actions field`.

Maintenance-related changes:
* Updated behavior when setting online field to use the status API
* Used new permission group fetching support in resource GET requests to avoid additional API calls